### PR TITLE
Fix S3 Version Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This allows the user to more easily generate type-safe Concourse CI pipelines, t
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatibility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
 To import everything, use:
 ```
-https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.0/package.dhall sha256:22b1cdb4a35dcac29a2da536f5c51a4b31d4c4dd71268756b054738afaae1da2
+https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/package.dhall sha256:5c2556c50bda96d2c2c085865e9a6f617a13772d0c1fa0d1a1fc1b2dfcece88f
 ```
 
 ## Intended Usage
@@ -50,16 +50,16 @@ This introduces a question - what should the type of the `source` field be? Main
 This repository allows the user to construct the type of `Resource` and of `ResourceType` based on a union that the downstream user constructs, consisting only of the resource types which the downstream user actually uses in their pipeline. This solves both the code-reusage problem, and keeps the implementation performant. For example:
 
 ```dhall
-let Git = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.0/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
+let Git = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
 
-let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.0/resource-types/S3.dhall sha256:6e062defd2cf94a3f7840d1b09c7a832d0a92467f5924a2b812843c053a8eca5
+let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/resource-types/S3.dhall sha256:1bf327b7abcfb70a3cd0dea52564df31f59094ae5698bcb19c8de191e437ccab
 
 let Source = < Git : Git.Source.Type | S3 : S3.Source.Type >
 
 let Version = < Git : Git.Version.Type | S3 : S3.Version.Type >
 
 let Resource =
-   let import = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.0/Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
+   let import = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
 
    in import { Source, Version }
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This allows the user to more easily generate type-safe Concourse CI pipelines, t
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatibility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
 To import everything, use:
 ```
-https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/package.dhall sha256:5c2556c50bda96d2c2c085865e9a6f617a13772d0c1fa0d1a1fc1b2dfcece88f
+https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/package.dhall sha256:ab25d95aaf255b8fc9572b58650c1850c9a4395d411576ced75611b893561c16
 ```
 
 ## Intended Usage
@@ -52,7 +52,7 @@ This repository allows the user to construct the type of `Resource` and of `Reso
 ```dhall
 let Git = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
 
-let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/resource-types/S3.dhall sha256:1bf327b7abcfb70a3cd0dea52564df31f59094ae5698bcb19c8de191e437ccab
+let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.6.1/resource-types/S3.dhall sha256:d9129408caf467ffa23f16470313cb58d4725687d26e043ee015c75b87f3c679
 
 let Source = < Git : Git.Source.Type | S3 : S3.Source.Type >
 

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { resource-types =
-      ./resource-types/package.dhall sha256:c31d891e5257473043c1cd40297c0c7eabcfc2e540345329bd8809b739a38d13
+      ./resource-types/package.dhall sha256:ab5a48fb1b46c887ff3448a7ca722bf98e4aa312b67abe436e76407707262f19
     ? ./resource-types/package.dhall
 , Resource =
       ./Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1

--- a/package.dhall
+++ b/package.dhall
@@ -1,5 +1,5 @@
 { resource-types =
-      ./resource-types/package.dhall sha256:ab5a48fb1b46c887ff3448a7ca722bf98e4aa312b67abe436e76407707262f19
+      ./resource-types/package.dhall sha256:19713724811bedcdbbaf2e3475877337f4c63582c36c91ecfc4e90a9f6eb694e
     ? ./resource-types/package.dhall
 , Resource =
       ./Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1

--- a/resource-types/S3.dhall
+++ b/resource-types/S3.dhall
@@ -1,5 +1,20 @@
 { meta = { name = "s3", repository = "concourse/s3-resource" }
-, Version.Type = < VersionID : { version_id : Text } | Path : { path : Text } >
+, Version =
+    let Options =
+          let VersionID = { version_id : Text }
+
+          let Path = { path : Text }
+
+          in  { VersionID, Path }
+
+    let Version = < VersionID : Options.VersionID | Path : Options.Path >
+
+    in  { Type = Version
+        , VersionID =
+            λ(version_id : Options.VersionID) → Version.VersionID version_id
+        , Path = λ(path : Options.Path) → Version.Path path
+        , Options
+        }
 , Params =
   { Get =
       let Get =

--- a/resource-types/S3.dhall
+++ b/resource-types/S3.dhall
@@ -1,5 +1,5 @@
 { meta = { name = "s3", repository = "concourse/s3-resource" }
-, Version = { Type = { version_id : Text }, default = {=} }
+, Version.Type = < VersionID : { version_id : Text } | Path : { path : Text } >
 , Params =
   { Get =
       let Get =

--- a/resource-types/package.dhall
+++ b/resource-types/package.dhall
@@ -23,7 +23,7 @@
       ./RegistryImage.dhall sha256:2ca4df79f82f54275f919d759344a6478749f7d0f32bddbc0389877ede11da03
     ? ./RegistryImage.dhall
 , S3 =
-      ./S3.dhall sha256:1bf327b7abcfb70a3cd0dea52564df31f59094ae5698bcb19c8de191e437ccab
+      ./S3.dhall sha256:d9129408caf467ffa23f16470313cb58d4725687d26e043ee015c75b87f3c679
     ? ./S3.dhall
 , S3Bucket =
       ./S3Bucket.dhall sha256:fc95953a8603a450c4e34b7394714332ede9759436256f153d00a829fddccc31

--- a/resource-types/package.dhall
+++ b/resource-types/package.dhall
@@ -23,7 +23,7 @@
       ./RegistryImage.dhall sha256:2ca4df79f82f54275f919d759344a6478749f7d0f32bddbc0389877ede11da03
     ? ./RegistryImage.dhall
 , S3 =
-      ./S3.dhall sha256:6e062defd2cf94a3f7840d1b09c7a832d0a92467f5924a2b812843c053a8eca5
+      ./S3.dhall sha256:1bf327b7abcfb70a3cd0dea52564df31f59094ae5698bcb19c8de191e437ccab
     ? ./S3.dhall
 , S3Bucket =
       ./S3Bucket.dhall sha256:fc95953a8603a450c4e34b7394714332ede9759436256f153d00a829fddccc31


### PR DESCRIPTION
The type of the S3 version depends on whether the resource source is
configured as a versioned file (i.e. the underlying object is versioned,
in which case `version_id` is used) or whether with a regex (i.e. the
underlying object is not necessarily versioned, and the version is
extracted from a regular expression, in which case `path` is used). This
commit fixes this discrepancy so that `path` versions can be pinned.