### PR TITLE
Add domain.dhall

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,20 @@ This allows the user to more easily generate type-safe Concourse CI pipelines, t
 
 ## Install
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatibility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
-To import everything, use:
+
+You should generally import `domain.dhall`, which includes `Resource`, `ResourceType`, `Step`, `Task`, `Job`, `Group`, `Pipeline`, and `VarSource`, and merge it with the resource types that you need. For example,
+```dhall
+let Concourse =
+        https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/domain.dhall sha256:036b9de47a7f54d4ed21b87c50987fb8a318c62524d7f6317d3ec98bbe9c784c
+      ∧ { RegistryImage =
+            https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/resource-types/RegistryImage.dhall sha256:2ca4df79f82f54275f919d759344a6478749f7d0f32bddbc0389877ede11da03
+        , Git =
+            https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
+        }
+
+in  Concourse
 ```
-https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.7.1/package.dhall sha256:d71d5c614768ab1abd898f328b26b137aa9118b22780ccb4dcf6a8e4f8a528d9
-```
+
 
 ## Intended Usage
 
@@ -51,16 +61,16 @@ This introduces a question - what should the type of the `source` field be? Main
 This repository allows the user to construct the type of `Resource` and of `ResourceType` based on a union that the downstream user constructs, consisting only of the resource types which the downstream user actually uses in their pipeline. This solves both the code-reusage problem, and keeps the implementation performant. For example:
 
 ```dhall
-let Git = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.7.1/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
+let Git = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/resource-types/Git.dhall sha256:830b9d7d0e9e0992ee2473f78e05838a86be3e13c7bcf5df661b8829dbc3d558
 
-let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.7.1/resource-types/S3.dhall sha256:b49ec06747630f6d6951fde4f04f7bbffab7cee1a9ef299464314ad049422d04
+let S3 = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/resource-types/S3.dhall sha256:b49ec06747630f6d6951fde4f04f7bbffab7cee1a9ef299464314ad049422d04
 
 let Source = < Git : Git.Source.Type | S3 : S3.Source.Type >
 
 let Version = < Git : Git.Version.Type | S3 : S3.Version.Type >
 
 let Resource =
-   let import = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.7.1/Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
+   let import = https://raw.githubusercontent.com/coralogix/dhall-concourse/v0.8.0/Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
 
    in import { Source, Version }
 

--- a/domain.dhall
+++ b/domain.dhall
@@ -1,0 +1,25 @@
+{ Resource =
+      ./Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
+    ? ./Resource.dhall
+, ResourceType =
+      ./ResourceType.dhall sha256:41ead24540852689f7d08893e4f354358a26696b1d96762e5b188615a031cc06
+    ? ./ResourceType.dhall
+, Step =
+      ./Step.dhall sha256:496795f751710c5feb68f8e70f685a095e81d826d9e376359609103b966266de
+    ? ./Step.dhall
+, Task =
+      ./Task.dhall sha256:8b7677ec0ce7822074fc4e86ad3d2080379c59305d8be4971bec532468a680e6
+    ? ./Task.dhall
+, Job =
+      ./Job.dhall sha256:84f8d5a8a81dae106a85655bd94a4469290222587ca07913907b39a7ebda5f6f
+    ? ./Job.dhall
+, Group =
+      ./Group.dhall sha256:9531fd9c8bfbd69c94798d00093481d5266384bd6eed2dc3d76713d7e7a56c41
+    ? ./Group.dhall
+, Pipeline =
+      ./Pipeline.dhall sha256:deb570e2d436b729ecfdf5f2a3fb96baa84321ce9950da95d4f412085cedca78
+    ? ./Pipeline.dhall
+, VarSource =
+      ./VarSource.dhall sha256:d40e04bc69b0ccb965bfeb14cd7c7f33b3c99636f4a75771115030d27775a655
+    ? ./VarSource.dhall
+}

--- a/package.dhall
+++ b/package.dhall
@@ -1,28 +1,5 @@
-{ resource-types =
-      ./resource-types/package.dhall sha256:94ec73f7b06436fa1c38b53905e059fab56546fdd51679eef802a62a5446991e
-    ? ./resource-types/package.dhall
-, Resource =
-      ./Resource.dhall sha256:206f784b14f3fb78809bafffbde955fbc177ca0427c8fe9cf4a983a8aaf463c1
-    ? ./Resource.dhall
-, ResourceType =
-      ./ResourceType.dhall sha256:41ead24540852689f7d08893e4f354358a26696b1d96762e5b188615a031cc06
-    ? ./ResourceType.dhall
-, Step =
-      ./Step.dhall sha256:496795f751710c5feb68f8e70f685a095e81d826d9e376359609103b966266de
-    ? ./Step.dhall
-, Task =
-      ./Task.dhall sha256:8b7677ec0ce7822074fc4e86ad3d2080379c59305d8be4971bec532468a680e6
-    ? ./Task.dhall
-, Job =
-      ./Job.dhall sha256:84f8d5a8a81dae106a85655bd94a4469290222587ca07913907b39a7ebda5f6f
-    ? ./Job.dhall
-, Group =
-      ./Group.dhall sha256:9531fd9c8bfbd69c94798d00093481d5266384bd6eed2dc3d76713d7e7a56c41
-    ? ./Group.dhall
-, Pipeline =
-      ./Pipeline.dhall sha256:deb570e2d436b729ecfdf5f2a3fb96baa84321ce9950da95d4f412085cedca78
-    ? ./Pipeline.dhall
-, VarSource =
-      ./VarSource.dhall sha256:d40e04bc69b0ccb965bfeb14cd7c7f33b3c99636f4a75771115030d27775a655
-    ? ./VarSource.dhall
-}
+  { resource-types =
+        ./resource-types/package.dhall sha256:94ec73f7b06436fa1c38b53905e059fab56546fdd51679eef802a62a5446991e
+      ? ./resource-types/package.dhall
+  }
+∧ ./domain.dhall


### PR DESCRIPTION
Splits off part of `package.dhall` into `domain.dhall`, as in general
most users will prefer to import everything in `domain.dhall` (but not
`package.dhall`) and importing `domain.dhall` instead of importing
`Resource`, `Job`, `Pipeline`, etc. separately will reduce boilerplate.